### PR TITLE
Added trim config to keep only the descends of a person

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ usage: oak_inspect.py [-h] --input_path INPUT_PATH
 options:
   -h, --help            show this help message and exit
   --input_path INPUT_PATH, -i INPUT_PATH
-                        Path to the family data.
+                        Path to the family data (a file or a folder).
 ```
 
 ### oak_tree
@@ -51,7 +51,7 @@ usage: oak_tree.py [-h] --input_path INPUT_PATH [--config_file_path CONFIG_FILE_
 options:
   -h, --help            show this help message and exit
   --input_path INPUT_PATH, -i INPUT_PATH
-                        Path to the file containing the family data.
+                        Path to the family data (a file or a folder).
   --config_file_path CONFIG_FILE_PATH, -c CONFIG_FILE_PATH
                         Path to the YAML file containing configuration of the family tree. This file is optionnal.
   --output_dir OUTPUT_DIR, -o OUTPUT_DIR

--- a/oak_stats.py
+++ b/oak_stats.py
@@ -51,7 +51,7 @@ def main(input_path: str, output_dir: str) -> None:
 if __name__ == "__main__":
   parser = ArgumentParser()
 
-  parser.add_argument("--input_path", "-i", type=str, required=True, help="Path to the file containing the family data.")
+  parser.add_argument("--input_path", "-i", type=str, required=True, help="Path to the family data (a file or a folder).")
   parser.add_argument("--output_dir", "-o", type=str, default=".", help="Path to the output directory. Take current folder as default.")
 
   args = parser.parse_args()

--- a/oak_tree.py
+++ b/oak_tree.py
@@ -8,15 +8,15 @@ from src.tree.draw import TreeConfiguration, draw_tree
 def main(input_path: str, config_file_path: str | None, output_dir: str) -> None:
   if not os.path.exists(output_dir): os.makedirs(output_dir)
 
-  family = Family.from_path(input_path)
   config = TreeConfiguration.from_path(config_file_path)
+  family = Family.from_path(input_path, config.trim_config.ignore_incomplete_relations)
   output_file_path = os.path.join(output_dir, config.filename)
 
   draw_tree(family, config, output_file_path)
 
 if __name__ == "__main__":
   parser = ArgumentParser()
-  parser.add_argument("--input_path", "-i", type=str, required=True, help="Path to the file containing the family data.")
+  parser.add_argument("--input_path", "-i", type=str, required=True, help="Path to the family data (a file or a folder).")
   parser.add_argument("--config_file_path", "-c", type=str, default=None, help="Path to the YAML file containing configuration of the family tree. This file is optionnal.")
   parser.add_argument("--output_dir", "-o", type=str, default=".", help="Path to the output directory. Take current folder as default.")
 

--- a/src/family.py
+++ b/src/family.py
@@ -6,6 +6,7 @@ import pandas as pd
 from src.person import Person
 from src.utils import ACCEPTED_EXTENSIONS, read_file_as_dict
 
+
 class FamilyPathInfos():
   def __init__(self, path: str):
     self.path = path
@@ -101,7 +102,7 @@ class Family():
       list[str]: The ids of the descendants of the person.
       list[str]: The ids of the descendants's spouses of the person.
     """
-    if id not in self.members: return []
+    if id not in self.members: return ([], [])
 
     descendants = []
     spouses = []

--- a/src/family.py
+++ b/src/family.py
@@ -6,7 +6,6 @@ import pandas as pd
 from src.person import Person
 from src.utils import ACCEPTED_EXTENSIONS, read_file_as_dict
 
-
 class FamilyPathInfos():
   def __init__(self, path: str):
     self.path = path
@@ -22,22 +21,31 @@ class Family():
   def __init__(self,
     name: str | None = None,
     members: dict[str, Person] = {},
-    path_info: FamilyPathInfos | None = None
+    path_info: FamilyPathInfos | None = None,
+    ignore_incomplete_relations: bool = False
   ):
     self.name = name
     self.members = members
     self.path_info = path_info
 
+    if ignore_incomplete_relations:
+      for value in members.values():
+        value.parents = [parent for parent in value.parents if parent in members.keys()]
+        value.spouses = [spouse for spouse in value.spouses if spouse in members.keys()]
+        value.childrens = [children for children in value.childrens if children in members.keys()]
+
+    # Count the number of descendants for each member
     for value in members.values():
       value.n_descendants = self.find_n_descendants(value)
 
   @classmethod
-  def from_path(cls, path: str):
+  def from_path(cls, path: str, ignore_incomplete_relations: bool = False):
     """
     Read a family from a path. If the path is a directory containing multiple files, the family will be the union of all the families in the files.
 
     Parameters:
       path (str): The path to the file or directory containing the family data.
+      ignore_incomplete_relations (bool): Ignore the incomplete relations between members. Default at False.
 
     Returns:
       Family: The family object.
@@ -59,7 +67,7 @@ class Family():
       print(f'Error: Could not read the family from file "{file}": {e}')
     
     family_name = " / ".join(names) if len(names) > 0 else None
-    return cls(family_name, members, path_info)
+    return cls(family_name, members, path_info, ignore_incomplete_relations)
     
   def find_n_descendants(self, person: Person) -> int:
     """
@@ -81,6 +89,35 @@ class Family():
       n += self.find_n_descendants(self.members[children])+1
     return n
   
+  def get_descendants(self, id: str, include_spouses: bool = False) -> tuple[list[str], list[str]]:
+    """
+    Get all descendants of a person.
+
+    Parameters:
+      id (str): The id of the person to get the descendants.
+      # include_spouses (bool): Include descendants's spouses in the list.
+
+    Returns:
+      list[str]: The ids of the descendants of the person.
+      list[str]: The ids of the descendants's spouses of the person.
+    """
+    if id not in self.members: return []
+
+    descendants = []
+    spouses = []
+
+    for child in self.members[id].childrens:
+      descendants.append(child)
+      if child not in self.members: continue
+      if include_spouses:
+        spouses += self.members[child].spouses
+
+      tmp_descendants, tmp_spouses = self.get_descendants(child, include_spouses)
+      descendants += tmp_descendants
+      spouses += tmp_spouses
+
+    return descendants, spouses
+
   def is_only_child(self, id: str) -> bool:
     """
     Check if a person is an only child. Doesn't count half-siblings.
@@ -99,28 +136,27 @@ class Family():
 
     return False
 
-  def remove_person(self, id: str) -> None:
+  def remove_persons(self, ids: list | set | None) -> None:
     """
-    Remove a person from the family.
+    Remove a list of persons from the family.
 
-    Parameters:
-      id (str): The id of the person to remove.
+    Parameters :
+      ids (list): The ids of the persons to remove.
 
     Returns:
       None
     """
-    if id in self.members:
-      del self.members[id]
+    if ids is None: return
+
+    for id in ids:
+      if id in self.members: del self.members[id]
 
     for person in self.members.values():
       person.n_descendants = None
 
-      if id in person.parents: 
-        person.parents = [i for i in person.parents if i != id]
-      if id in person.spouses:
-        person.spouses = [i for i in person.spouses if i != id]
-      if id in person.childrens:
-        person.childrens = [i for i in person.childrens if i != id]
+      person.parents = [i for i in person.parents if i not in ids]
+      person.spouses = [i for i in person.spouses if i not in ids]
+      person.childrens = [i for i in person.childrens if i not in ids]
     
     for person in self.members.values():
       person.n_descendants = self.find_n_descendants(person)

--- a/src/tree/README.md
+++ b/src/tree/README.md
@@ -1,0 +1,49 @@
+# Tree command
+
+## Configuration file
+
+The file can specified the following fields to customize the tree :
+|Field|Type|Description|Default value|
+|-----|-----|-----|-----|
+|`background_color`     | `str`               | Color of the background of the image. See [Color Names of Graphviz](https://graphviz.org/doc/info/colors.html). | `""`  |
+|`filename`             | `str`               | Name of the generated file.                                                                                     | `"family_tree.png"` |
+|`person_label_config`  | `PersonLabelConfig` | TODO | / |
+|`title_config`         | `TitleConfig`       | TODO | / |
+|`trim_config`          | `TrimConfig`        | TODO | / |
+|`start_person`         | `str`               | ID of the person from where to start generating the tree                                                        | `None` |
+
+### Edge config
+TODO
+
+### Node config
+TODO
+
+### Person label config
+Config to customize how the text of a person is rendered (the label of a node). In the field `person_label_config` :
+
+|Field|Type|Description|Default value|
+|-----|-----|-----|-----|
+|`bold_names`         | `bool`  | Bold the label                                        | `True`  |
+|`show_nationalities` | `bool`  | Show the nationalities as flag                        | `True`  |
+|`show_nickname`      | `bool`  | Show the nickname (in quotes)                         | `True`  |
+|`show_years`         | `bool`  | Show the birth and death years                        | `True`  |
+|`split_names`        | `bool`  | Add a return to line between the first and last names | `False` |
+|`upper_last_name`    | `bool`  | Put the last name in uppercase                        | `False` |
+
+### Title config
+Config to customize how the title of tree is rendered. In the field `title_config` :
+
+|Field|Type|Description|Default value|
+|-----|-----|-----|-----|
+|`enabled`  | `bool`   | Show the title of the tree                                                                                   | `True`  |
+|`location` | `str`    | Location of the title in the image. See [`labelloc` of Graphviz](https://graphviz.org/docs/attrs/labelloc/)  | `"t"`   |
+| `title`   | `str`    | Text of the title. Will use the title property of a Family object if no title is given                       | `None`  |
+
+### Trim config
+Config to select the persons to show in tree. In the field `trim_config` :
+
+|Field|Type|Description|Default value|
+|-----|-----|-----|-----|
+|`descendants_of`               | `str`       | ID of the person whose only the descendants will be kept in the tree          | `None`  |
+|`ignore`                       | `list[str]` | List of id of persons to ignore in the family tree                            | `[]`    |
+|`ignore_incomplete_relations`  | `bool`      | Ignore or not the relations who point to a person who doesn't exist in tree.  | `False` |

--- a/src/tree/configs/trim_config.py
+++ b/src/tree/configs/trim_config.py
@@ -1,0 +1,9 @@
+class TrimConfig():
+  def __init__(self,
+    descendants_of: str | None = None,
+    ignore: list[str] = [],
+    ignore_incomplete_relations: bool = False
+  ):
+    self.descendants_of = descendants_of
+    self.ignore = ignore
+    self.ignore_incomplete_relations = ignore_incomplete_relations

--- a/src/tree/configuration.py
+++ b/src/tree/configuration.py
@@ -2,6 +2,7 @@ from src.tree.configs.edge_config import EdgeConfig
 from src.tree.configs.node_config import NodeConfig
 from src.tree.configs.person_label_config import PersonLabelConfig
 from src.tree.configs.title_config import TitleConfig
+from src.tree.configs.trim_config import TrimConfig
 from src.utils import dict_key_as_object, read_file_as_dict
 
 
@@ -13,8 +14,8 @@ class TreeConfiguration():
     node_config: NodeConfig = NodeConfig(**{}),
     person_label_config: PersonLabelConfig = PersonLabelConfig(**{}),
     title_config: TitleConfig = TitleConfig(**{}),
-    ignore: list[str] = [],
     start_person: str | None = None,
+    trim_config: TrimConfig = TrimConfig(**{})
   ):
     self.background_color = background_color
     self.edge_config = edge_config
@@ -22,8 +23,8 @@ class TreeConfiguration():
     self.node_config = node_config
     self.person_label_config = person_label_config
     self.title_config = title_config
-    self.ignore = ignore
     self.start_person = start_person
+    self.trim_config = trim_config
   
   @classmethod
   def from_path(cls, path: str | None):
@@ -35,5 +36,6 @@ class TreeConfiguration():
     dict_key_as_object(dict_config, "node_config", NodeConfig)
     dict_key_as_object(dict_config, "person_label_config", PersonLabelConfig)
     dict_key_as_object(dict_config, "title_config", TitleConfig)
+    dict_key_as_object(dict_config, "trim_config", TrimConfig)
     
     return cls(**dict_config)

--- a/src/tree/draw.py
+++ b/src/tree/draw.py
@@ -4,7 +4,7 @@ from src.family import Family
 from src.person import Person
 from src.tree.configuration import TreeConfiguration
 from src.utils import apply_dict
-
+from src.tree.trim import trim
 
 def get_union_name(parents: list[str]) -> str:
   """
@@ -112,6 +112,7 @@ def add_parents_to_tree(
   for parent in person.parents:
     generate_generations(family.members[parent], family, generations, current_generation-1, already_seen, tree, childrens_subgraphs)
 
+
 def generate_generations(
   person: Person,
   family: Family,
@@ -142,6 +143,7 @@ def generate_generations(
       generations[current_generation].add_member(spouse)
       already_seen.add(spouse)
 
+      # Add edge between the spouses and their union node
       tree.add_edge(person.id, union_name)
       tree.add_edge(union_name, spouse)
 
@@ -167,12 +169,10 @@ def get_persons_list(family: Family, config: TreeConfiguration) -> list[Person]:
   Returns:
     list[Person]: the list of persons to draw in the tree.
   """
+  # Trim the family tree by removing unwanted members
+  trim(family, config.trim_config)
 
-  # Remove ignored persons
-  for person_id in config.ignore:
-    family.remove_person(person_id)
-
-  # Order persons of the family by n_descendants descending order
+  # Order remaining members of the family by n_descendants descending order
   persons = list(family.members.values())
   persons.sort(key=lambda x : x.n_descendants if x.n_descendants is not None else 0)
   persons.reverse()

--- a/src/tree/draw.py
+++ b/src/tree/draw.py
@@ -3,8 +3,9 @@ import pygraphviz as pgv
 from src.family import Family
 from src.person import Person
 from src.tree.configuration import TreeConfiguration
-from src.utils import apply_dict
 from src.tree.trim import trim
+from src.utils import apply_dict
+
 
 def get_union_name(parents: list[str]) -> str:
   """

--- a/src/tree/trim.py
+++ b/src/tree/trim.py
@@ -1,0 +1,36 @@
+from src.family import Family
+from src.tree.configs.trim_config import TrimConfig
+
+def keep_only_descendants(family: Family, descendants_of: str) -> None:
+  """
+  Remove the persons which are not the descendants of the specified id "descendants_of". 
+
+  Paremeters:
+    family (Family): the family object with all the persons.
+    descendants_of (str): the ID of the persons to keep the descendants.
+
+  Returns:
+    None
+  """
+
+  descendants, spouses = family.get_descendants(descendants_of, True)
+  new_family_ids = descendants + spouses + [descendants_of] + family.members[descendants_of].spouses
+  ids_to_remove = set(family.members.keys()).difference(new_family_ids)
+  family.remove_persons(ids_to_remove)
+
+def trim(family: Family, config: TrimConfig) -> None:
+  """
+  Trim the family tree.
+  
+  Parameters:
+    family (Family): the family object with all the persons.
+    config (TrimConfig): the trim configuration to remove unwanted persons.
+  
+  Returns:
+    None
+  """
+  # Remove ignored persons
+  family.remove_persons(config.ignore)
+
+  # Keep only descendants if specified
+  if config.descendants_of is not None: keep_only_descendants(family, config.descendants_of)

--- a/src/tree/trim.py
+++ b/src/tree/trim.py
@@ -1,6 +1,7 @@
 from src.family import Family
 from src.tree.configs.trim_config import TrimConfig
 
+
 def keep_only_descendants(family: Family, descendants_of: str) -> None:
   """
   Remove the persons which are not the descendants of the specified id "descendants_of". 


### PR DESCRIPTION
* Added `trim_config` with the following options to manage the persons to show in the tree :
   * `ignore`, to remove specific persons
   * descendants_of, to keep only the descendants of a specific person
   *  `ignore_incomplete_relations`, to remove incomplete relations between persons (ex: a person has a parent ID that is not in the list of users).
 * Started a `REAMDE` with the list of options to customize the tree output.