### PR TITLE
Added support for descendants in oak_sunburst

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ options:
 Generate a family as a sunburst with Plotly :
 
 ```
-usage: oak_sunburst.py [-h] --input_path INPUT_PATH --person_id PERSON_ID [--output_dir OUTPUT_DIR] [--output_filename OUTPUT_FILENAME] [--output_format OUTPUT_FORMAT]
-                       [--max_depth MAX_DEPTH] [--no_interactive] [--weighted]
+usage: oak_sunburst.py [-h] --input_path INPUT_PATH --person_id PERSON_ID [--output_dir OUTPUT_DIR] [--output_filename OUTPUT_FILENAME] [--output_format OUTPUT_FORMAT] [--max_depth MAX_DEPTH] [--no_interactive]
+                       [--equally_weighted] [--type {ancestors,descendants}]
 
 options:
   -h, --help            show this help message and exit
@@ -97,11 +97,14 @@ options:
   --output_filename OUTPUT_FILENAME, -fi OUTPUT_FILENAME
                         Name of the file. Default to 'suburst'.
   --output_format OUTPUT_FORMAT, -fo OUTPUT_FORMAT
-                        Extension of the output file. Accepted format : 'png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf', 'html'. Default to 'png'.
+                        Extension of the output file. Accepted format : 'png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf', 'html'. Default to 'html'.
   --max_depth MAX_DEPTH, -d MAX_DEPTH
                         Maximum number of layer to renderer. Default to -1 to show the complete hiearchy.
-  --no_interactive      Don't show the interactive sunburst window with Plotly.
-  --weighted            Use the real number of ancestors as width for each sector
+  --no_interactive, -ni
+                        Don't show the interactive sunburst window with Plotly.
+  --equally_weighted, -ew
+                        Weight all sectors at the same depth equally.
+  --type {ancestors,descendants}, -t {ancestors,descendants}
 ```
 
 You may have to install additionnal packages to save the sunburst as an image.

--- a/oak_sunburst.py
+++ b/oak_sunburst.py
@@ -12,7 +12,8 @@ def main(
   output_format: str,
   max_depth: int,
   no_interactive: bool,
-  weighted: bool
+  weighted: bool,
+  sunburst_type: str
 ) -> None:
   family = Family.from_path(input_path)
 
@@ -24,7 +25,8 @@ def main(
     output_format,
     max_depth,
     no_interactive,
-    weighted
+    weighted,
+    sunburst_type
   )
 
 if __name__ == "__main__":
@@ -36,7 +38,8 @@ if __name__ == "__main__":
   parser.add_argument("--output_format", "-fo", type=str, default="html", help="Extension of the output file. Accepted format : 'png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf', 'html'. Default to 'html'.")
   parser.add_argument("--max_depth", "-d", type=int, default=-1, help="Maximum number of layer to renderer. Default to -1 to show the complete hiearchy.")
   parser.add_argument("--no_interactive", action="store_true", help="Don't show the interactive sunburst window with Plotly.")
-  parser.add_argument("--weighted", action="store_true", help="Use the real number of ancestors as width for each sector")
+  parser.add_argument("--weighted", action="store_true", help="Use the real number of ancestors as width for each sector.")
+  parser.add_argument("--type", "-t", type=str, default="ancestors", choices=["ancestors", "descendants"], help="Type of sunburst to draw: 'ancestors' or 'descendants'. Default to 'ancestors'.")
 
   args = parser.parse_args()
   main(
@@ -47,5 +50,6 @@ if __name__ == "__main__":
     args.output_format,
     args.max_depth,
     args.no_interactive,
-    args.weighted
+    args.weighted,
+    args.type
   )

--- a/oak_sunburst.py
+++ b/oak_sunburst.py
@@ -12,7 +12,7 @@ def main(
   output_format: str,
   max_depth: int,
   no_interactive: bool,
-  weighted: bool,
+  equally_weighted: bool,
   sunburst_type: str
 ) -> None:
   family = Family.from_path(input_path)
@@ -25,7 +25,7 @@ def main(
     output_format,
     max_depth,
     no_interactive,
-    weighted,
+    equally_weighted,
     sunburst_type
   )
 
@@ -37,8 +37,8 @@ if __name__ == "__main__":
   parser.add_argument("--output_filename", "-fi", type=str, default="sunburst", help="Name of the file. Default to 'suburst'.")
   parser.add_argument("--output_format", "-fo", type=str, default="html", help="Extension of the output file. Accepted format : 'png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf', 'html'. Default to 'html'.")
   parser.add_argument("--max_depth", "-d", type=int, default=-1, help="Maximum number of layer to renderer. Default to -1 to show the complete hiearchy.")
-  parser.add_argument("--no_interactive", action="store_true", help="Don't show the interactive sunburst window with Plotly.")
-  parser.add_argument("--weighted", action="store_true", help="Use the real number of ancestors as width for each sector.")
+  parser.add_argument("--no_interactive", "-ni", action="store_true", help="Don't show the interactive sunburst window with Plotly.")
+  parser.add_argument("--equally_weighted", "-ew", action="store_true", help="Weight all sectors at the same depth equally.")
   parser.add_argument("--type", "-t", type=str, default="ancestors", choices=["ancestors", "descendants"], help="Type of sunburst to draw: 'ancestors' or 'descendants'. Default to 'ancestors'.")
 
   args = parser.parse_args()
@@ -50,6 +50,6 @@ if __name__ == "__main__":
     args.output_format,
     args.max_depth,
     args.no_interactive,
-    args.weighted,
+    args.equally_weighted,
     args.type
   )

--- a/src/sunburst/ancestor.py
+++ b/src/sunburst/ancestor.py
@@ -24,11 +24,13 @@ def get_ancestors_sunburst_data(
     depth_dict: dict[str, int] = {},
 ) -> tuple[list[str], list[str], dict[str, int]]:
     """
-    Get the sunburst data (ids, parents, depths) for the ancestors of a person.
+    Get the sunburst data (ids, parents, depths) for the ancestors of a person recursively.
 
     Parameters:
         family (Family): The family object.
-        person_id (str): The id of the person to get the ancestors for.
+        person_id (str): The id of the person to get the ancestors for. Default to an empty list.
+        persons (list[str]): List of the persons to plot. Default to an empty list.
+        parents (list[str]): List of the parent of each persons. Default to an empty dict.
         depth_dict (dict[str, int]): A dictionary to store the depth of each person.
 
     Returns:

--- a/src/sunburst/ancestor.py
+++ b/src/sunburst/ancestor.py
@@ -1,5 +1,6 @@
 from src.family import Family
 
+
 def count_ancestors(n_generations: int) -> int:
   """
   Calculate the number of ancestors for a given number of generations.

--- a/src/sunburst/ancestor.py
+++ b/src/sunburst/ancestor.py
@@ -1,0 +1,58 @@
+from src.family import Family
+
+def count_ancestors(n_generations: int) -> int:
+  """
+  Calculate the number of ancestors for a given number of generations.
+
+  Parameters:
+    n_generations (int): The number of generations.
+
+  Returns:
+    int: The number of ancestors.
+  """
+  total = 0
+  for i in range(n_generations):
+    if i == 0: total = 2
+    else: total += pow(2, i + 1)
+  return total
+
+def get_ancestors_sunburst_data(
+    family: Family,
+    person_id: str,
+    persons: list[str] = [],
+    parents: list[str] = [],
+    depth_dict: dict[str, int] = {},
+) -> tuple[list[str], list[str], dict[str, int]]:
+    """
+    Get the sunburst data (ids, parents, depths) for the ancestors of a person.
+
+    Parameters:
+        family (Family): The family object.
+        person_id (str): The id of the person to get the ancestors for.
+        depth_dict (dict[str, int]): A dictionary to store the depth of each person.
+
+    Returns:
+        tuple[list[str], list[str], dict[str]]: A tuple containing the list of person ids,
+        the list of parent ids, and the depth dictionary.
+    """
+    if person_id not in family.members: return persons, parents, depth_dict
+    
+    person_data = family.members[person_id]
+
+    for parent_id in person_data.parents:
+        if parent_id not in family.members: continue
+
+        # Add ancestor
+        persons.append(parent_id)
+        parents.append(person_id)
+
+        # Update depth
+        max_depth = 0
+        for child in family.members[parent_id].childrens:
+            if child in depth_dict: 
+                max_depth = max(max_depth, depth_dict[child]+1)
+        depth_dict[parent_id] = max_depth
+
+        _, _, _ = get_ancestors_sunburst_data(family, parent_id, persons, parents, depth_dict)
+ 
+    return persons, parents, depth_dict

--- a/src/sunburst/descendant.py
+++ b/src/sunburst/descendant.py
@@ -1,0 +1,26 @@
+from src.family import Family
+
+def get_descendants_sunburst_data(
+    family: Family,
+    person_id: str,
+    persons: list[str] = [],
+    parents: list[str] = [],
+    split_dict: dict[str, float] = {}
+) -> tuple[list[str], list[str], dict[str, float]]:
+
+    # TODO : throw an error ?
+    if person_id not in family.members: return persons, parents, split_dict
+
+    person_data = family.members[person_id]
+
+    for child_id in person_data.childrens:
+        if child_id not in family.members: continue
+        # Add descendant
+        persons.append(child_id)
+        parents.append(person_id)
+
+        split_dict[child_id] = split_dict.get(person_id, 1) / len(person_data.childrens)
+
+        _, _, _ = get_descendants_sunburst_data(family, child_id, persons, parents, split_dict)
+    
+    return persons, parents, split_dict

--- a/src/sunburst/descendant.py
+++ b/src/sunburst/descendant.py
@@ -5,11 +5,21 @@ def get_descendants_sunburst_data(
     person_id: str,
     persons: list[str] = [],
     parents: list[str] = [],
-    split_dict: dict[str, float] = {}
+    repartition_dict: dict[str, float] = {}
 ) -> tuple[list[str], list[str], dict[str, float]]:
+    """
+    Get the sunburst data (ids, parents, values) for the descendants of a person recursively.
+
+    Parameters:
+        family (Family): The family object.
+        person_id (str): The id of the person to get the descendants for. Default to an empty list.
+        persons (list[str]): List of the persons to plot. Default to an empty list.
+        parents (list[str]): List of the parent of each persons. Default to an empty dict.
+        repartition_dict (dict[str, float]): A dictionary to store the % of the size of the sector of a person.
+    """
 
     # TODO : throw an error ?
-    if person_id not in family.members: return persons, parents, split_dict
+    if person_id not in family.members: return persons, parents, repartition_dict
 
     person_data = family.members[person_id]
 
@@ -19,8 +29,8 @@ def get_descendants_sunburst_data(
         persons.append(child_id)
         parents.append(person_id)
 
-        split_dict[child_id] = split_dict.get(person_id, 1) / len(person_data.childrens)
+        repartition_dict[child_id] = repartition_dict.get(person_id, 1) / len(person_data.childrens)
 
-        _, _, _ = get_descendants_sunburst_data(family, child_id, persons, parents, split_dict)
+        _, _, _ = get_descendants_sunburst_data(family, child_id, persons, parents, repartition_dict)
     
-    return persons, parents, split_dict
+    return persons, parents, repartition_dict

--- a/src/sunburst/descendant.py
+++ b/src/sunburst/descendant.py
@@ -1,5 +1,6 @@
 from src.family import Family
 
+
 def get_descendants_sunburst_data(
     family: Family,
     person_id: str,

--- a/src/sunburst/sunburst.py
+++ b/src/sunburst/sunburst.py
@@ -3,56 +3,9 @@ import os
 import plotly.graph_objects as go
 
 from src.family import Family
+from src.sunburst.ancestor import count_ancestors, get_ancestors_sunburst_data
+from src.sunburst.descendant import get_descendants_sunburst_data
 
-
-def get_ancestors_sunburst_data(
-    family: Family,
-    person_id: str,
-    depth_dict: dict[str, int] = {}
-) -> tuple[list[str], list[str], dict[str, int]]:
-    """
-    Get the sunburst data (ids, parents, depths) for the ancestors of a person.
-
-    Parameters:
-        family (Family): The family object.
-        person_id (str): The id of the person to get the ancestors for.
-        depth_dict (dict[str, int]): A dictionary to store the depth of each person.
-
-    Returns:
-        tuple[list[str], list[str], dict[str]]: A tuple containing the list of person ids,
-        the list of parent ids, and the depth dictionary.
-    """
-    persons: list[str] = []
-    parents: list[str] = []
-
-    if person_id not in family.members: return persons, parents, depth_dict
-    
-    person_data = family.members[person_id]
-    
-    if len(person_data.childrens) == 0:
-        persons.append(person_id)
-        parents.append("")
-        depth_dict[person_id] = 0
-
-    for parent_id in person_data.parents:
-        if parent_id not in family.members: continue
-
-        # Add ancestor
-        persons.append(parent_id)
-        parents.append(person_id)
-
-        # Update depth
-        max_depth = 0
-        for child in family.members[parent_id].childrens:
-            if child in depth_dict: 
-                max_depth = max(max_depth, depth_dict[child]+1)
-        depth_dict[parent_id] = max_depth
-
-        sub_persons, sub_parents, _ = get_ancestors_sunburst_data(family, parent_id, depth_dict)
-        persons += sub_persons
-        parents += sub_parents
-
-    return persons, parents, depth_dict
 
 def write_image(fig: go.Figure, output_dir: str | None, output_filename: str, output_format: str) -> None:
     """
@@ -79,6 +32,39 @@ def write_image(fig: go.Figure, output_dir: str | None, output_filename: str, ou
     else:
         raise ValueError(f"Unsupported output format: {output_format}")
 
+def generate_sunburst_config(
+    type: str,
+    family: Family,
+    person_id: str,
+    weighted: bool
+):
+    if type == "ancestors":
+        persons, parents, depth_dict = get_ancestors_sunburst_data(family, person_id, [person_id], [""], {person_id: 0})
+
+        # Values
+        max_depth_dict = max(depth_dict.values()) if len(depth_dict) > 0 else 0
+        values = [pow(2, max_depth_dict - depth_dict.get(person, 0)) for person in persons] if weighted else None
+        
+        # Layout field
+        title = f"Ancestors of {family.members[person_id].full_name()}"
+        subtitle = f"{len(persons)-1} ancestors found on {count_ancestors(max_depth_dict)} possible ancestors"
+
+        return persons, parents, values, title, subtitle
+    elif type == "descendants":
+        persons, parents, split_dict = get_descendants_sunburst_data(family, person_id, [person_id], [""], {person_id: 1})
+        
+        # Values
+        n_descendants = len(persons)-1
+        values = [n_descendants * split_dict.get(person, 0) for person in persons] if weighted else None
+
+        # Layout field
+        title = f"Descendants of {family.members[person_id].full_name()}"
+        subtitle = f"{n_descendants} descendants found"
+
+        return persons, parents, values, title, subtitle
+    else:
+        raise ValueError(f"Unsupported sunburst type : {type}")
+
 def draw_sunburst(
     family: Family,
     person_id: str,
@@ -87,7 +73,8 @@ def draw_sunburst(
     output_format: str,
     max_depth: int,
     no_interactive: bool,
-    weighted: bool
+    weighted: bool,
+    type: str
 ) -> None:
     """
     Draw a sunburst chart of the ancestors of a person in the family.
@@ -100,23 +87,23 @@ def draw_sunburst(
         output_format (str): The format of the output file.
         max_depth (int): The maximum depth to display in the sunburst. -1 for no limit.
         no_interactive (bool): If True, do not show the interactive sunburst window.
-        weighted (bool): If True, use the real number of ancestors as width for each sector
+        weighted (bool): If True, use the real number of ancestors as width for each sector.
+        type (str): ...
     """
-    persons, parents, depth_dict = get_ancestors_sunburst_data(family, person_id)
-    max_depth_dict = max(depth_dict.values()) if len(depth_dict) > 0 else 0
+    ids, parents, values, title, subtitle = generate_sunburst_config(type, family, person_id, weighted)
 
     fig = go.Figure(go.Sunburst(
-        ids=persons,
-        labels=[family.members[person].full_name() for person in persons],
+        ids=ids,
+        labels=[family.members[person].full_name() for person in ids],
         parents=parents,
-        values=[pow(2, max_depth_dict - depth_dict.get(person, 0)) for person in persons] if weighted else None,
+        values=values,
         branchvalues="total",
         maxdepth=max_depth,
     ))
 
     fig.update_layout(
-        title_text=f"Ancestors of {family.members[person_id].full_name()}",
-        title_subtitle_text=f"{len(persons)-1} ancestors found on {pow(2, max_depth_dict)} possible ancestors"
+        title_text=title,
+        title_subtitle_text=subtitle
     )
 
     if not no_interactive: fig.show()

--- a/src/sunburst/sunburst.py
+++ b/src/sunburst/sunburst.py
@@ -32,18 +32,32 @@ def write_image(fig: go.Figure, output_dir: str | None, output_filename: str, ou
     else:
         raise ValueError(f"Unsupported output format: {output_format}")
 
-def generate_sunburst_config(
+def generate_sunburst_data(
     type: str,
     family: Family,
     person_id: str,
-    weighted: bool
-):
+    equally_weighted: bool
+) -> tuple[list[str], list[str], list[float] | None, str, str]:
+    """
+    Generate the data for the sunburst chart.
+
+    Parameters:
+        type (str): Type of relationship to render. Either "ancestors" or "descendants".
+        family (Family): The family object.
+        person_id (str): The id of the person to draw the sunburst for.
+        equally_weighted (bool): If True, weight all sectors at the same depth equally.
+
+    Returns:
+        tuple[list[str], list[str], list[float] | None, str, str]: tuple with the list of persons, the list of parents, the list of values, the title and the subtitle.
+    """
+
     if type == "ancestors":
+        # Persons data
         persons, parents, depth_dict = get_ancestors_sunburst_data(family, person_id, [person_id], [""], {person_id: 0})
 
         # Values
         max_depth_dict = max(depth_dict.values()) if len(depth_dict) > 0 else 0
-        values = [pow(2, max_depth_dict - depth_dict.get(person, 0)) for person in persons] if weighted else None
+        values = [pow(2, max_depth_dict - depth_dict.get(person, 0)) for person in persons] if equally_weighted else None
         
         # Layout field
         title = f"Ancestors of {family.members[person_id].full_name()}"
@@ -51,11 +65,12 @@ def generate_sunburst_config(
 
         return persons, parents, values, title, subtitle
     elif type == "descendants":
-        persons, parents, split_dict = get_descendants_sunburst_data(family, person_id, [person_id], [""], {person_id: 1})
+        # Persons data
+        persons, parents, repartition_dict = get_descendants_sunburst_data(family, person_id, [person_id], [""], {person_id: 1})
         
         # Values
         n_descendants = len(persons)-1
-        values = [n_descendants * split_dict.get(person, 0) for person in persons] if weighted else None
+        values = [n_descendants * repartition_dict.get(person, 0) for person in persons] if equally_weighted else None
 
         # Layout field
         title = f"Descendants of {family.members[person_id].full_name()}"
@@ -73,7 +88,7 @@ def draw_sunburst(
     output_format: str,
     max_depth: int,
     no_interactive: bool,
-    weighted: bool,
+    equally_weighted: bool,
     type: str
 ) -> None:
     """
@@ -87,10 +102,10 @@ def draw_sunburst(
         output_format (str): The format of the output file.
         max_depth (int): The maximum depth to display in the sunburst. -1 for no limit.
         no_interactive (bool): If True, do not show the interactive sunburst window.
-        weighted (bool): If True, use the real number of ancestors as width for each sector.
-        type (str): ...
+        equally_weighted (bool): If True, weight all sectors at the same depth equally.
+        type (str): Type of relationship to render. Either "ancestors" or "descendants".
     """
-    ids, parents, values, title, subtitle = generate_sunburst_config(type, family, person_id, weighted)
+    ids, parents, values, title, subtitle = generate_sunburst_data(type, family, person_id, equally_weighted)
 
     fig = go.Figure(go.Sunburst(
         ids=ids,


### PR DESCRIPTION
## Changes
* Added support for showing the descendants of a person with the `oak_sunburst` command with the `type` argument.
* Renamed command options for better clarity.
* Fixed the number of total ancestors showed in the subtitle.

## Issues
* Closes #48 