### PR TITLE
Added an option to keep only direct ancestors in a family tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!IMPORTANT]
 > **⚠️ This is a work in progress. ⚠️**
 
-# Oak 🌳
+# Oak
 
 Group of tools to work with genealogical data.
 
@@ -31,7 +31,9 @@ The data is expected to follow the [`Family`](https://github.com/hvdbm/Oak/blob/
 
 ## Commands
 
-### 🔍 oak_inspect
+### Utils
+
+#### 🔍 oak_inspect
 
 Inspect for available data at a path and show a summary of the files, persons and warnings.
 
@@ -44,7 +46,24 @@ options:
                         Path to the family data (a file or a folder).
 ```
 
-### 🌳 oak_tree
+#### 📊 oak_stats
+
+Generate stats from the infos of the members of a family :
+
+```
+usage: oak_stats.py [-h] --input_path INPUT_PATH [--output_dir OUTPUT_DIR]
+
+options:
+  -h, --help            show this help message and exit
+  --input_path INPUT_PATH, -i INPUT_PATH
+                        Path to the family data.
+  --output_dir OUTPUT_DIR, -o OUTPUT_DIR
+                        Path to the output directory. Take current folder as default.
+```
+
+### Family visualization
+
+#### 🌳 oak_tree
 
 Generate a family as a tree graph with Graphviz :
 
@@ -63,28 +82,14 @@ options:
 
 See [Tree README](src/tree/README.md) for more infos on the config file.
 
-### 📊 oak_stats
-
-Generate stats from the infos of the members of a family :
-
-```
-usage: oak_stats.py [-h] --input_path INPUT_PATH [--output_dir OUTPUT_DIR]
-
-options:
-  -h, --help            show this help message and exit
-  --input_path INPUT_PATH, -i INPUT_PATH
-                        Path to the family data.
-  --output_dir OUTPUT_DIR, -o OUTPUT_DIR
-                        Path to the output directory. Take current folder as default.
-```
-
-### ☀️ oak_sunburst
+#### ☀️ oak_sunburst
 
 Generate a family as a sunburst with Plotly :
 
 ```
-usage: oak_sunburst.py [-h] --input_path INPUT_PATH --person_id PERSON_ID [--output_dir OUTPUT_DIR] [--output_filename OUTPUT_FILENAME] [--output_format OUTPUT_FORMAT] [--max_depth MAX_DEPTH] [--no_interactive]
-                       [--equally_weighted] [--type {ancestors,descendants}]
+usage: oak_sunburst.py [-h] --input_path INPUT_PATH --person_id PERSON_ID [--output_dir OUTPUT_DIR]
+                       [--output_filename OUTPUT_FILENAME] [--output_format OUTPUT_FORMAT] [--max_depth MAX_DEPTH]
+                       [--no_interactive] [--equally_weighted] [--type {ancestors,descendants}]
 
 options:
   -h, --help            show this help message and exit
@@ -97,7 +102,8 @@ options:
   --output_filename OUTPUT_FILENAME, -fi OUTPUT_FILENAME
                         Name of the file. Default to 'suburst'.
   --output_format OUTPUT_FORMAT, -fo OUTPUT_FORMAT
-                        Extension of the output file. Accepted format : 'png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf', 'html'. Default to 'html'.
+                        Extension of the output file. Accepted format : 'png', 'jpg', 'jpeg', 'webp', 'svg', 'pdf',
+                        'html'. Default to 'html'.
   --max_depth MAX_DEPTH, -d MAX_DEPTH
                         Maximum number of layer to renderer. Default to -1 to show the complete hiearchy.
   --no_interactive, -ni
@@ -105,6 +111,7 @@ options:
   --equally_weighted, -ew
                         Weight all sectors at the same depth equally.
   --type {ancestors,descendants}, -t {ancestors,descendants}
+                        Type of sunburst to draw: 'ancestors' or 'descendants'. Default to 'ancestors'.
 ```
 
 You may have to install additionnal packages to save the sunburst as an image.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ optional-dependencies.dev = [
 
 [tool.mypy]
 disable_error_code = ["import-untyped"]
+exclude = ["build/*"]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "pandas==2.2.3",
   "plotly==6.3.1",
   "pycountry==24.6.1",
+  "pydantic==2.12.3",
   "pygraphviz==1.14",
   "pyyaml==6.0.2",
   "seaborn==0.13.2",

--- a/src/family.py
+++ b/src/family.py
@@ -51,7 +51,6 @@ class Family():
     Returns:
       Family: The family object.
     """
-
     path_info = FamilyPathInfos(path)
 
     members: dict[str, Person] = {}
@@ -90,13 +89,25 @@ class Family():
       n += self.find_n_descendants(self.members[children])+1
     return n
   
+  def get_ancestors(self, id: str) -> list[str]:
+    if id not in self.members: return []
+
+    ancestors = []
+
+    for parent in self.members[id].parents:
+      if parent not in self.members: continue
+      ancestors.append(parent)
+      ancestors += self.get_ancestors(parent)
+    
+    return ancestors
+
   def get_descendants(self, id: str, include_spouses: bool = False) -> tuple[list[str], list[str]]:
     """
-    Get all descendants of a person.
+    Get all the descendants ids of a person.
 
     Parameters:
       id (str): The id of the person to get the descendants.
-      # include_spouses (bool): Include descendants's spouses in the list.
+      include_spouses (bool): Include descendants's spouses in the list.
 
     Returns:
       list[str]: The ids of the descendants of the person.

--- a/src/family.py
+++ b/src/family.py
@@ -81,7 +81,7 @@ class Family():
     Returns:
       int: The number of descendants of the person.
     """
-    if person.id in self.n_descendants: return self.n_descendants.get(person.id)
+    if person.id in self.n_descendants: return self.n_descendants[person.id]
     if person.childrens == []: return 0
 
     n = 0

--- a/src/family.py
+++ b/src/family.py
@@ -19,6 +19,8 @@ class FamilyPathInfos():
       self.files = [path]
 
 class Family():
+  n_descendants: dict[str, int] = {}
+
   def __init__(self,
     name: str | None = None,
     members: dict[str, Person] = {},
@@ -36,8 +38,8 @@ class Family():
         value.childrens = [children for children in value.childrens if children in members.keys()]
 
     # Count the number of descendants for each member
-    for value in members.values():
-      value.n_descendants = self.find_n_descendants(value)
+    for person in members.values():
+      self.n_descendants[person.id] = self.__count_n_descendants(person)
 
   @classmethod
   def from_path(cls, path: str, ignore_incomplete_relations: bool = False):
@@ -69,9 +71,9 @@ class Family():
     family_name = " / ".join(names) if len(names) > 0 else None
     return cls(family_name, members, path_info, ignore_incomplete_relations)
     
-  def find_n_descendants(self, person: Person) -> int:
+  def __count_n_descendants(self, person: Person) -> int:
     """
-    Find the number of descendants of a person. This number is calculated recursively.
+    Count the number of descendants of a person. This number is calculated recursively.
 
     Parameters:
       person (Person): The person to find the number of descendants.
@@ -79,14 +81,13 @@ class Family():
     Returns:
       int: The number of descendants of the person.
     """
-
+    if person.id in self.n_descendants: return self.n_descendants.get(person.id)
     if person.childrens == []: return 0
-    if person.n_descendants is not None: return person.n_descendants
 
     n = 0
     for children in person.childrens:
       if children not in self.members: continue
-      n += self.find_n_descendants(self.members[children])+1
+      n += self.__count_n_descendants(self.members[children])+1
     return n
   
   def get_ancestors(self, id: str) -> list[str]:
@@ -164,14 +165,14 @@ class Family():
       if id in self.members: del self.members[id]
 
     for person in self.members.values():
-      person.n_descendants = None
+      self.n_descendants.pop(person.id)
 
       person.parents = [i for i in person.parents if i not in ids]
       person.spouses = [i for i in person.spouses if i not in ids]
       person.childrens = [i for i in person.childrens if i not in ids]
     
     for person in self.members.values():
-      person.n_descendants = self.find_n_descendants(person)
+      self.n_descendants[person.id] = self.__count_n_descendants(person)
 
   def to_df(self) -> pd.DataFrame:
     """

--- a/src/person.py
+++ b/src/person.py
@@ -31,9 +31,6 @@ class Person():
     self.spouses = spouses
     self.childrens = childrens
 
-    # Calculated properties
-    self.n_descendants: int | None = None
-
   def full_name(self) -> str:
     """
     Get the full name of the person.

--- a/src/tree/README.md
+++ b/src/tree/README.md
@@ -44,6 +44,7 @@ Config to select the persons to show in tree. In the field `trim_config` :
 
 |Field|Type|Description|Default value|
 |-----|-----|-----|-----|
-|`descendants_of`               | `str`       | ID of the person whose only the descendants will be kept in the tree   | `None`  |
+|`ancestors_of`               | `AncestorsOfConfig`       | TODO  | `None`  |
+|`descendants_of`               | `DescendantsOfConfig`       | TODO  | `None`  |
 |`ignore`                       | `list[str]` | List of id of persons to ignore in the family tree                     | `[]`    |
 |`ignore_incomplete_relations`  | `bool`      | Ignore the relations with a person who doesn't exist in tree           | `False` |

--- a/src/tree/configs/edge_config.py
+++ b/src/tree/configs/edge_config.py
@@ -1,32 +1,22 @@
-class EdgeStyle():
-  def __init__(self,
-    color: str = "black",
-    dir: str = "none",
-    minlen: int = 1,
-    penwidth: float = 1.0,
-    style: str = "solid",
-    start_node: str = "",
-    end_node: str = "",
-  ):
-    # Style
-    self.color = color
-    self.dir = dir
-    self.minlen = minlen
-    self.penwidth = penwidth
-    self.style = style
+from pydantic import BaseModel
 
-    # Position
-    self.start_node = start_node
-    self.end_node = end_node
+class EdgeStyle(BaseModel):
+  color: str = "black"
+  dir: str = "none"
+  minlen: int = 1
+  penwidth: float = 1.0
+  style: str = "solid"
+  start_node: str = ""
+  end_node: str = ""
 
 class EdgeConfig(EdgeStyle):
+  edges: dict[tuple[str, str], EdgeStyle] = {}
+  
   def __init__(self,
     edges: list[dict] = [],
     **kwargs
   ):
     super().__init__(**kwargs)
-
-    self.edges = {}
 
     for edge in edges:
       edge_style = {**kwargs, **edge}

--- a/src/tree/configs/edge_config.py
+++ b/src/tree/configs/edge_config.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class EdgeStyle(BaseModel):
   color: str = "black"
   dir: str = "none"
@@ -20,6 +21,8 @@ class EdgeConfig(EdgeStyle):
 
     for edge in edges:
       edge_style = {**kwargs, **edge}
-      key = (edge.get("start_node"), edge.get("end_node"))
+      if "start_node" not in edge or "end_node" not in edge:
+        continue
+      key = (edge["start_node"], edge["end_node"])
       self.edges[key] = EdgeStyle(**edge_style)
 

--- a/src/tree/configs/font_config.py
+++ b/src/tree/configs/font_config.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+
 class FontConfig(BaseModel):
   fontcolor: str = "black"
   fontname: str = "Times-Roman"

--- a/src/tree/configs/font_config.py
+++ b/src/tree/configs/font_config.py
@@ -1,9 +1,6 @@
-class FontConfig():
-  def __init__(self,
-    fontcolor: str = "black",
-    fontname: str = "Times-Roman",
-    fontsize: float = 12,
-  ):
-    self.fontcolor = fontcolor
-    self.fontname = fontname
-    self.fontsize = fontsize
+from pydantic import BaseModel
+
+class FontConfig(BaseModel):
+  fontcolor: str = "black"
+  fontname: str = "Times-Roman"
+  fontsize: float = 12

--- a/src/tree/configs/node_config.py
+++ b/src/tree/configs/node_config.py
@@ -22,9 +22,7 @@ class ConditionalNodeStyle(BaseModel):
   def __init__(self,
     **kwargs
   ):
-
     super().__init__(**kwargs)
-
     self.style_args = {**kwargs}
 
 class NodeConfig(NodeStyle):
@@ -39,8 +37,10 @@ class NodeConfig(NodeStyle):
     super().__init__(**kwargs)
 
     for node in nodes:
+      # Check that the node has an id
+      if "id" not in node: continue
+      key = node["id"]
       node_style = {**kwargs, **node}
-      key = node.get("id")
       self.nodes[key] = NodeStyle(**node_style)
 
     for conditional_node in conditional_nodes:

--- a/src/tree/configs/node_config.py
+++ b/src/tree/configs/node_config.py
@@ -1,44 +1,36 @@
+from pydantic import BaseModel
+
 from src.tree.configs.font_config import FontConfig
 
 
 class NodeStyle(FontConfig):
+  id: str = ""
+  color: str = "black"
+  fillcolor: str = "white"
+  height: str = ""
+  imagepos: str = "tc"
+  labelloc: str = ""
+  shape: str = "box"
+  style: str = "filled"
+
+class ConditionalNodeStyle(BaseModel):
+  key: str = ""
+  value: str = ""
+  operator: str = "=="
+  style_args: dict = {}
+
   def __init__(self,
-    id: str = "",
-    color: str = "black",
-    fillcolor: str = "white",
-    height: str = "",
-    imagepos: str = "tc",
-    labelloc: str = "",
-    shape: str = "box",
-    style: str = "filled",
     **kwargs
   ):
-    self.id = id
-
-    self.color = color
-    self.fillcolor = fillcolor
-    self.height = height
-    self.imagepos = imagepos
-    self.labelloc = labelloc
-    self.shape = shape
-    self.style = style
 
     super().__init__(**kwargs)
-
-class ConditionalNodeStyle():
-  def __init__(self,
-    key: str = "",
-    value: str = "",
-    operator: str = "==",
-    **kwargs
-  ):
-    self.key = key
-    self.value = value
-    self.operator = operator
 
     self.style_args = {**kwargs}
 
 class NodeConfig(NodeStyle):
+  nodes: dict[str, NodeStyle] = {}
+  conditional_nodes: list[ConditionalNodeStyle] = []
+
   def __init__(self,
     conditional_nodes: list[dict] = [],
     nodes: list[dict] = [],
@@ -46,13 +38,11 @@ class NodeConfig(NodeStyle):
   ):
     super().__init__(**kwargs)
 
-    self.nodes = {}
     for node in nodes:
       node_style = {**kwargs, **node}
       key = node.get("id")
       self.nodes[key] = NodeStyle(**node_style)
 
-    self.conditional_nodes = []
     for conditional_node in conditional_nodes:
       self.conditional_nodes.append(ConditionalNodeStyle(**conditional_node))
     

--- a/src/tree/configs/person_label_config.py
+++ b/src/tree/configs/person_label_config.py
@@ -1,24 +1,17 @@
 import pycountry
+from pydantic import BaseModel
 
 from src.person import Person
 from src.tree.label import bold, newline
 
 
-class PersonLabelConfig():
-  def __init__(self,
-    bold_names: bool = True,
-    show_nationalities: bool = True,
-    show_nickname: bool = True,
-    show_years: bool = True,
-    split_names: bool = False,
-    upper_last_name: bool = False
-  ):
-    self.bold_names = bold_names
-    self.show_nationalities = show_nationalities
-    self.show_nickname = show_nickname
-    self.show_years = show_years
-    self.split_names = split_names
-    self.upper_last_name = upper_last_name
+class PersonLabelConfig(BaseModel):
+  bold_names: bool = True
+  show_nationalities: bool = True
+  show_nickname: bool = True
+  show_years: bool = True
+  split_names: bool = False
+  upper_last_name: bool = False  
 
   def get_names_label(self, person: Person) -> str:
     """

--- a/src/tree/configs/title_config.py
+++ b/src/tree/configs/title_config.py
@@ -3,17 +3,9 @@ from src.tree.label import bold, newline
 
 
 class TitleConfig(FontConfig):
-  def __init__(self,
-    enabled: bool = True,
-    location: str = "t",
-    title: str | None = None,
-    **kwargs
-  ):
-    self.enabled = enabled
-    self.location = location
-    self.title = title
-
-    FontConfig.__init__(self, **kwargs)
+  enabled: bool = True
+  location: str = "t"
+  title: str | None = None
 
   def get_label(self, label: str | None = None) -> str:
     if not self.enabled: return ""

--- a/src/tree/configs/trim_config.py
+++ b/src/tree/configs/trim_config.py
@@ -1,11 +1,15 @@
-class TrimConfig():
-  def __init__(self,
-    ancestors_of: str | None = None,
-    descendants_of: str | None = None,
-    ignore: list[str] = [],
-    ignore_incomplete_relations: bool = False
-  ):
-    self.ancestors_of = ancestors_of
-    self.descendants_of = descendants_of
-    self.ignore = ignore
-    self.ignore_incomplete_relations = ignore_incomplete_relations
+from pydantic import BaseModel
+
+
+class AncestorsOfConfig(BaseModel):
+  of: str
+
+class DescendantsOfConfig(BaseModel):
+  of: str
+  include_spouses: bool = True
+
+class TrimConfig(BaseModel):
+  ancestors_of: AncestorsOfConfig | None = None
+  descendants_of: DescendantsOfConfig | None = None
+  ignore: list[str] = []
+  ignore_incomplete_relations: bool = False

--- a/src/tree/configs/trim_config.py
+++ b/src/tree/configs/trim_config.py
@@ -1,9 +1,11 @@
 class TrimConfig():
   def __init__(self,
+    ancestors_of: str | None = None,
     descendants_of: str | None = None,
     ignore: list[str] = [],
     ignore_incomplete_relations: bool = False
   ):
+    self.ancestors_of = ancestors_of
     self.descendants_of = descendants_of
     self.ignore = ignore
     self.ignore_incomplete_relations = ignore_incomplete_relations

--- a/src/tree/configuration.py
+++ b/src/tree/configuration.py
@@ -7,6 +7,7 @@ from src.tree.configs.title_config import TitleConfig
 from src.tree.configs.trim_config import TrimConfig
 from src.utils import read_file_as_dict
 
+
 class TreeConfiguration(BaseModel):
   background_color: str = ""
   edge_config: EdgeConfig = EdgeConfig()

--- a/src/tree/configuration.py
+++ b/src/tree/configuration.py
@@ -1,41 +1,30 @@
+from pydantic import BaseModel
+
 from src.tree.configs.edge_config import EdgeConfig
 from src.tree.configs.node_config import NodeConfig
 from src.tree.configs.person_label_config import PersonLabelConfig
 from src.tree.configs.title_config import TitleConfig
 from src.tree.configs.trim_config import TrimConfig
-from src.utils import dict_key_as_object, read_file_as_dict
+from src.utils import read_file_as_dict
 
-
-class TreeConfiguration():
-  def __init__(self,
-    background_color: str = "",
-    edge_config: EdgeConfig = EdgeConfig(**{}),
-    filename: str = "family_tree.png",
-    node_config: NodeConfig = NodeConfig(**{}),
-    person_label_config: PersonLabelConfig = PersonLabelConfig(**{}),
-    title_config: TitleConfig = TitleConfig(**{}),
-    start_person: str | None = None,
-    trim_config: TrimConfig = TrimConfig(**{})
-  ):
-    self.background_color = background_color
-    self.edge_config = edge_config
-    self.filename = filename
-    self.node_config = node_config
-    self.person_label_config = person_label_config
-    self.title_config = title_config
-    self.start_person = start_person
-    self.trim_config = trim_config
+class TreeConfiguration(BaseModel):
+  background_color: str = ""
+  edge_config: EdgeConfig = EdgeConfig()
+  filename: str = "family_tree.png"
+  node_config: NodeConfig = NodeConfig()
+  person_label_config: PersonLabelConfig = PersonLabelConfig()
+  title_config: TitleConfig = TitleConfig()
+  trim_config: TrimConfig = TrimConfig()
+  start_person: str | None = None
   
+  @classmethod
+  def from_dict(cls, dict_config: dict):
+    return cls(**dict_config)
+
   @classmethod
   def from_path(cls, path: str | None):
     if path is None: dict_config = {}
     else:
       dict_config = read_file_as_dict(path)
     
-    dict_key_as_object(dict_config, "edge_config", EdgeConfig)
-    dict_key_as_object(dict_config, "node_config", NodeConfig)
-    dict_key_as_object(dict_config, "person_label_config", PersonLabelConfig)
-    dict_key_as_object(dict_config, "title_config", TitleConfig)
-    dict_key_as_object(dict_config, "trim_config", TrimConfig)
-    
-    return cls(**dict_config)
+    return cls.from_dict(dict_config)

--- a/src/tree/draw.py
+++ b/src/tree/draw.py
@@ -175,7 +175,7 @@ def get_persons_list(family: Family, config: TreeConfiguration) -> list[Person]:
 
   # Order remaining members of the family by n_descendants descending order
   persons = list(family.members.values())
-  persons.sort(key=lambda x : x.n_descendants if x.n_descendants is not None else 0)
+  persons.sort(key=lambda x : family.n_descendants.get(x.id, 0))
   persons.reverse()
 
   # If a start person is defined, move it to the first position

--- a/src/tree/trim.py
+++ b/src/tree/trim.py
@@ -1,7 +1,19 @@
 from src.family import Family
-from src.tree.configs.trim_config import TrimConfig, AncestorsOfConfig, DescendantsOfConfig
+from src.tree.configs.trim_config import (AncestorsOfConfig,
+                                          DescendantsOfConfig, TrimConfig)
+
 
 def keep_only_ancestors(family: Family, config: AncestorsOfConfig) -> None:
+  """
+  Remove the persons which are not the ancestors of the person specified in the config.
+
+  Paremeters:
+    family (Family): the family object with all the persons.
+    config (AncestorsOfConfig): the config of the persons to keep the ancestors.
+
+  Returns:
+    None
+  """
   ancestors = family.get_ancestors(config.of)
   new_family_ids = ancestors + [config.of]
   ids_to_remove = set(family.members.keys()).difference(new_family_ids)
@@ -9,11 +21,11 @@ def keep_only_ancestors(family: Family, config: AncestorsOfConfig) -> None:
 
 def keep_only_descendants(family: Family, config: DescendantsOfConfig) -> None:
   """
-  Remove the persons which are not the descendants of the specified id "config". 
+  Remove the persons which are not the descendants of the person specified in the config.
 
   Paremeters:
     family (Family): the family object with all the persons.
-    config (str): the ID of the persons to keep the descendants.
+    config (DescendantsOfConfig): the config of the persons to keep the descendants.
 
   Returns:
     None

--- a/src/tree/trim.py
+++ b/src/tree/trim.py
@@ -1,6 +1,11 @@
 from src.family import Family
 from src.tree.configs.trim_config import TrimConfig
 
+def keep_only_ancestors(family: Family, ancestors_of: str) -> None:
+  ancestors = family.get_ancestors(ancestors_of)
+  new_family_ids = ancestors + [ancestors_of]
+  ids_to_remove = set(family.members.keys()).difference(new_family_ids)
+  family.remove_persons(ids_to_remove)
 
 def keep_only_descendants(family: Family, descendants_of: str) -> None:
   """
@@ -13,8 +18,7 @@ def keep_only_descendants(family: Family, descendants_of: str) -> None:
   Returns:
     None
   """
-
-  descendants, spouses = family.get_descendants(descendants_of, True)
+  descendants, spouses = family.get_descendants(descendants_of, False)
   new_family_ids = descendants + spouses + [descendants_of] + family.members[descendants_of].spouses
   ids_to_remove = set(family.members.keys()).difference(new_family_ids)
   family.remove_persons(ids_to_remove)
@@ -32,6 +36,9 @@ def trim(family: Family, config: TrimConfig) -> None:
   """
   # Remove ignored persons
   family.remove_persons(config.ignore)
+
+  # Keep only ancestors if specified
+  if config.ancestors_of is not None: keep_only_ancestors(family, config.ancestors_of)
 
   # Keep only descendants if specified
   if config.descendants_of is not None: keep_only_descendants(family, config.descendants_of)

--- a/src/tree/trim.py
+++ b/src/tree/trim.py
@@ -1,25 +1,25 @@
 from src.family import Family
-from src.tree.configs.trim_config import TrimConfig
+from src.tree.configs.trim_config import TrimConfig, AncestorsOfConfig, DescendantsOfConfig
 
-def keep_only_ancestors(family: Family, ancestors_of: str) -> None:
-  ancestors = family.get_ancestors(ancestors_of)
-  new_family_ids = ancestors + [ancestors_of]
+def keep_only_ancestors(family: Family, config: AncestorsOfConfig) -> None:
+  ancestors = family.get_ancestors(config.of)
+  new_family_ids = ancestors + [config.of]
   ids_to_remove = set(family.members.keys()).difference(new_family_ids)
   family.remove_persons(ids_to_remove)
 
-def keep_only_descendants(family: Family, descendants_of: str) -> None:
+def keep_only_descendants(family: Family, config: DescendantsOfConfig) -> None:
   """
-  Remove the persons which are not the descendants of the specified id "descendants_of". 
+  Remove the persons which are not the descendants of the specified id "config". 
 
   Paremeters:
     family (Family): the family object with all the persons.
-    descendants_of (str): the ID of the persons to keep the descendants.
+    config (str): the ID of the persons to keep the descendants.
 
   Returns:
     None
   """
-  descendants, spouses = family.get_descendants(descendants_of, False)
-  new_family_ids = descendants + spouses + [descendants_of] + family.members[descendants_of].spouses
+  descendants, spouses = family.get_descendants(config.of, config.include_spouses)
+  new_family_ids = descendants + spouses + [config.of] + family.members[config.of].spouses
   ids_to_remove = set(family.members.keys()).difference(new_family_ids)
   family.remove_persons(ids_to_remove)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,10 +8,6 @@ def apply_dict(obj: dict, dict: dict) -> None:
   for key, value in dict.items():
     obj[key] = value
 
-def dict_key_as_object(dict_config: dict, key: str, c) -> None:
-  if key in dict_config:
-    dict_config[key] = c(**dict_config.get(key))
-
 def read_file_as_dict(file_path: str) -> dict:
   extentions = file_path.split(".")[-1]
     


### PR DESCRIPTION
## Changes
* Added `ancestors_of` field to `TrimConfig`.
* Converted `descendants_of` field to a class and an option to keep or not the spouses of descendants.
* Added `pydantic` to manage nested config files.
* Moved `n_descendants` field from the `Person` class to the `Family` class.

## Issues
* Related to #31